### PR TITLE
Changes to API for Folder Retrieval

### DIFF
--- a/src/LaravelBox/Commands/Folders/GetFolderItemsCommand.php
+++ b/src/LaravelBox/Commands/Folders/GetFolderItemsCommand.php
@@ -33,6 +33,7 @@ class GetFolderItemsCommand extends AbstractFolderCommand
             'query' => [
                 'offset' => ($offset >= 0) ? $offset : 0,
                 'limit' => ($limit >= 1) ? ($limit <= 1000) ? $limit : 1000 : 1,
+		'fields' => 'modified_at,path_collection,name,size',
             ],
             'headers' => [
                 'Authorization' => "Bearer ${token}",


### PR DESCRIPTION
This expands the meta data when requesting folder info from the API.

This is necessary for the other PR on flysystem-box.